### PR TITLE
feat(main): Adapt to ramdisk type boot media, use CPIO format, and add test script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ arceboot.bin
 rustsbi/
 
 /.axconfig.*
+
+*.cpio

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,7 @@ dependencies = [
  "axlog",
  "axmm",
  "axnet",
+ "cfg-if",
  "chrono",
  "crate_interface",
  "ctor_bare",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 authors = ["Zhihang Shao <dio_ro@outlook.com>", "Jingxuan Wei <jensenwei007@gmail.com>"]
 
 [features]
-default = ["alloc", "fs", "paging", "disk"]
+default = ["alloc", "fs", "paging", "ramdisk_cpio"]
 
 alloc = ["axalloc"]
 paging = ["axhal/paging", "axmm"]
@@ -14,7 +14,10 @@ fs = ["axdriver", "axfs"]
 net = ["axdriver", "axnet"]
 display = ["axdriver", "axdisplay"]
 
-disk = ["axdriver/virtio-blk"]
+# Boot Media
+
+virtiodisk = ["axdriver/virtio-blk"]
+ramdisk_cpio = []
 
 [dependencies]
 axhal = { git = "https://github.com/arceos-org/arceos.git" }
@@ -29,5 +32,6 @@ axdisplay = { git = "https://github.com/arceos-org/arceos.git", optional = true 
 
 crate_interface = "0.1"
 ctor_bare = "0.2"
+cfg-if = "1.0"
 
 chrono = { version = "0.4.38", default-features = false }

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 #     - `PLATFORM`: Target platform in the `platforms` directory
 #     - `SMP`: Number of CPUs
 #     - `LOG:` Logging level: warn, error, info, debug, trace
+#     - `MEDIA:` Boot Media Type: ramdisk-cpio, virtio-blk
 #     - `EXTRA_CONFIG`: Extra config specification file
 #     - `OUT_CONFIG`: Final config file that takes effect
 # * QEMU options:
@@ -14,7 +15,8 @@
 ARCH ?= riscv64
 PLATFORM ?=
 SMP ?= 1
-LOG ?= info
+LOG ?= debug
+MEDIA ?= ramdisk-cpio
 
 OUT_CONFIG ?= $(PWD)/.axconfig.toml
 EXTRA_CONFIG ?=
@@ -22,6 +24,7 @@ EXTRA_CONFIG ?=
 # QEMU options
 DISK:= fat32_disk_test.img
 SBI:=rustsbi/target/riscv64imac-unknown-none-elf/release/rustsbi-prototyper-payload.elf
+RAMDISK_CPIO:=ramdisk.cpio
 
 export AX_CONFIG_PATH=$(OUT_CONFIG)
 export AX_LOG=$(LOG)
@@ -44,5 +47,8 @@ clean:
 
 build: clean defconfig all
 
+ramdiskcpio:
+	qemu-system-riscv64 -m 128M -serial mon:stdio -bios $(SBI) -nographic -machine virt -device loader,file=$(RAMDISK_CPIO),addr=0x84000000
+
 run:
-	qemu-system-riscv64 -serial mon:stdio -bios $(SBI) -nographic -machine virt -device virtio-blk-pci,drive=disk0 -drive id=disk0,if=none,format=raw,file=$(DISK)
+	qemu-system-riscv64 -m 128M -serial mon:stdio -bios $(SBI) -nographic -machine virt -device virtio-blk-pci,drive=disk0 -drive id=disk0,if=none,format=raw,file=$(DISK)

--- a/scripts/test/ramdisk_cpio.sh
+++ b/scripts/test/ramdisk_cpio.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+
+print_info() {
+    printf "\033[1;37m%s\033[0m" "[RustSBI-Arceboot Build For Test] "
+    printf "\033[1;32m%s\033[0m" "[INFO] "
+    printf "\033[36m%s\033[0m\n" "$1"
+}
+
+print_info "开始执行 ramdisk 类型的 cpio 打包脚本"
+print_info "此为空镜像, 只含有一个 arceboot.txt 文件, 用于测试 Arceboot"
+print_info "即将在当前目录执行创建 -------->"
+
+mkdir myramdisk
+touch myramdisk/arceboot.txt
+echo "This is a test file for Arceboot." > myramdisk/arceboot.txt
+
+cd myramdisk
+find . | cpio -o --format=newc > ../ramdisk.cpio
+cd ..
+
+rm -rf myramdisk
+
+print_info "创建完成, 生成的 ramdisk.cpio 位于当前目录"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ extern crate axlog;
 
 mod panic;
 mod log;
+mod media;
 
 #[cfg_attr(not(test), unsafe(no_mangle))]
 pub extern "C" fn rust_main(_cpu_id: usize, _dtb: usize) -> ! {
@@ -39,7 +40,9 @@ pub extern "C" fn rust_main(_cpu_id: usize, _dtb: usize) -> ! {
         let all_devices = axdriver::init_drivers();
 
         #[cfg(feature = "fs")]
-        axfs::init_filesystems(all_devices.block);
+        // 目前使用ramdisk的cpio格式时，驱动还不完善，用不了，需要注释掉
+        // 如果使用virtio-blk驱动，则可以正常使用
+        //axfs::init_filesystems(all_devices.block);
 
         #[cfg(feature = "net")]
         axnet::init_network(all_devices.net);
@@ -48,6 +51,10 @@ pub extern "C" fn rust_main(_cpu_id: usize, _dtb: usize) -> ! {
         axdisplay::init_display(all_devices.display);
     }
     ctor_bare::call_ctors();
+
+    info!("will test cpio.");
+
+    crate::media::parse_cpio_ramdisk();
 
     info!("will shut down.");
 

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -1,0 +1,8 @@
+cfg_if::cfg_if! {
+    if #[cfg(feature = "ramdisk_cpio")] {
+        mod ramdisk_cpio;
+        pub use ramdisk_cpio::*;
+    } else {
+        info!("Boot media feature is not enabled.");
+    }
+}

--- a/src/media/ramdisk_cpio.rs
+++ b/src/media/ramdisk_cpio.rs
@@ -1,0 +1,82 @@
+use core::{ptr, str};
+use axhal::mem::phys_to_virt;
+
+const CPIO_MAGIC: &[u8; 6] = b"070701";
+const CPIO_BASE: usize = 0x8400_0000;
+
+#[repr(C)]
+#[derive(Debug)]
+struct CpioNewcHeader {
+    c_magic: [u8; 6],
+    c_ino: [u8; 8],
+    c_mode: [u8; 8],
+    c_uid: [u8; 8],
+    c_gid: [u8; 8],
+    c_nlink: [u8; 8],
+    c_mtime: [u8; 8],
+    c_filesize: [u8; 8],
+    c_devmajor: [u8; 8],
+    c_devminor: [u8; 8],
+    c_rdevmajor: [u8; 8],
+    c_rdevminor: [u8; 8],
+    c_namesize: [u8; 8],
+    c_check: [u8; 8],
+}
+
+fn parse_hex_field(field: &[u8]) -> usize {
+    // 将ASCII十六进制转换为数字
+    let s = core::str::from_utf8(field).unwrap_or("0");
+    usize::from_str_radix(s, 16).unwrap_or(0)
+}
+
+pub fn parse_cpio_ramdisk() {
+    let mut ptr = phys_to_virt(CPIO_BASE.into()).as_usize();
+
+    loop {
+        let hdr = unsafe { &*(ptr as *const CpioNewcHeader) };
+
+        if &hdr.c_magic != CPIO_MAGIC {
+            info!("Invalid magic at {:#x}", ptr);
+            break;
+        }
+
+        let namesize = parse_hex_field(&hdr.c_namesize);
+        let filesize = parse_hex_field(&hdr.c_filesize);
+
+        // 文件名在 header 后面紧跟着
+        let name_ptr = ptr + core::mem::size_of::<CpioNewcHeader>();
+        let name = unsafe {
+            let slice = core::slice::from_raw_parts(name_ptr as *const u8, namesize - 1); // 去掉末尾的 '\0'
+            str::from_utf8(slice).unwrap_or("<invalid utf8>")
+        };
+
+        if name == "TRAILER!!!" {
+            info!("End of CPIO archive.");
+            break;
+        }
+
+        info!("Found file: {}, size: {}", name, filesize);
+
+        // 文件数据
+        let file_start = align_up(name_ptr + namesize, 4);
+        let file_end = file_start + filesize;
+
+        if name == "arceboot.txt" {
+            let data = unsafe {
+                core::slice::from_raw_parts(file_start as *const u8, filesize)
+            };
+            if let Ok(text) = core::str::from_utf8(data) {
+                info!("Content of {}:\n{}", name, text);
+            } else {
+                info!("Binary content of {}: {:02x?}", name, &data[0..core::cmp::min(32, data.len())]);
+            }
+        }
+
+        // 移动到下一个 header
+        ptr = align_up(file_end, 4);
+    }
+}
+
+fn align_up(addr: usize, align: usize) -> usize {
+    (addr + align - 1) & !(align - 1)
+}


### PR DESCRIPTION
feat(main): Adapt to ramdisk type boot media, use CPIO format, and add test script

- Add boot media type compilation options and source code adaptation
- Add ramdisk boot media type (CPIO format)
- Add test suite for ramdisk boot media type (CPIO format)

run successfully pic:
<img width="726" alt="image" src="https://github.com/user-attachments/assets/1dcf33aa-ac9d-46ca-b042-0f3fbcf07a13" />

run logs:
```
root@504e42dcb5c8:~/arceboot# make ramdiskcpio
qemu-system-riscv64 -m 128M -serial mon:stdio -bios /root/arceboot/rustsbi/target/riscv64imac-unknown-none-elf/release/rustsbi-prototyper-payload.elf -nographic -machine virt -device loader,file=ramdisk.cpio,addr=0x84000000
[RustSBI] INFO  - Hello RustSBI!
[RustSBI] INFO  - RustSBI version 0.4.0
[RustSBI] INFO  - .______       __    __      _______.___________.  _______..______   __
[RustSBI] INFO  - |   _  \     |  |  |  |    /       |           | /       ||   _  \ |  |
[RustSBI] INFO  - |  |_)  |    |  |  |  |   |   (----`---|  |----`|   (----`|  |_)  ||  |
[RustSBI] INFO  - |      /     |  |  |  |    \   \       |  |      \   \    |   _  < |  |
[RustSBI] INFO  - |  |\  \----.|  `--'  |.----)   |      |  |  .----)   |   |  |_)  ||  |
[RustSBI] INFO  - | _| `._____| \______/ |_______/       |__|  |_______/    |______/ |__|
[RustSBI] INFO  - Initializing RustSBI machine-mode environment.
[RustSBI] INFO  - Platform Name                 : riscv-virtio,qemu
[RustSBI] INFO  - Platform HART Count           : 1
[RustSBI] INFO  - Enabled HARTs                 : [0]
[RustSBI] INFO  - Platform IPI Extension        : SiFiveClint (Base Address: 0x2000000)
[RustSBI] INFO  - Platform Console Extension    : Uart16550U8 (Base Address: 0x10000000)
[RustSBI] INFO  - Platform Reset Extension      : Available (Base Address: 0x100000)
[RustSBI] INFO  - Platform HSM Extension        : Available
[RustSBI] INFO  - Platform RFence Extension     : Available
[RustSBI] INFO  - Platform SUSP Extension       : Available
[RustSBI] INFO  - Platform PMU Extension        : Available
[RustSBI] INFO  - Memory range                  : 0x80000000 - 0x88000000
[RustSBI] INFO  - Platform Status               : Platform initialization complete and ready.
[RustSBI] INFO  - PMP Configuration
[RustSBI] INFO  - PMP        Range      Permission      Address                       
[RustSBI] INFO  - PMP 0:     OFF        NONE            0x00000000
[RustSBI] INFO  - PMP 1-2:   TOR        RWX/RWX         0x80000000 - 0x80000000
[RustSBI] INFO  - PMP 3-5:   TOR        NONE/NONE       0x80019000 - 0x80024000 - 0x80051000
[RustSBI] INFO  - PMP 6:     TOR        RWX             0x88000000
[RustSBI] INFO  - PMP 7:     TOR        RWX             0xffffffffffffffff
[RustSBI] INFO  - Boot HART ID                  : 0
[RustSBI] INFO  - Boot HART Privileged Version: : Version1_12
[RustSBI] INFO  - Boot HART MHPM Mask:          : 0x07ffff
[RustSBI] INFO  - Redirecting hart 0 to 0x00000080200000 in Supervisor mode.
[  0.019691 0 arceboot:15] Logging is enabled.
[  0.021507 0 arceboot:17] Found physcial memory regions:
[  0.022200 0 axhal::mem:130] default free regions
[  0.023045 0 arceboot:19]   [PA:0x80200000, PA:0x80210000) .text (READ | EXECUTE | RESERVED)
[  0.024380 0 arceboot:19]   [PA:0x80210000, PA:0x80216000) .rodata (READ | RESERVED)
[  0.025655 0 arceboot:19]   [PA:0x80216000, PA:0x80219000) .data .tdata .tbss .percpu (READ | WRITE | RESERVED)
[  0.027210 0 arceboot:19]   [PA:0x80219000, PA:0x80259000) boot stack (READ | WRITE | RESERVED)
[  0.028444 0 arceboot:19]   [PA:0x80259000, PA:0x8025d000) .bss (READ | WRITE | RESERVED)
[  0.029706 0 arceboot:19]   [PA:0x8025d000, PA:0x88000000) free memory (READ | WRITE | FREE)
[  0.030802 0 arceboot:19]   [PA:0x101000, PA:0x102000) mmio (READ | WRITE | DEVICE | RESERVED)
[  0.031910 0 arceboot:19]   [PA:0xc000000, PA:0xc210000) mmio (READ | WRITE | DEVICE | RESERVED)
[  0.033020 0 arceboot:19]   [PA:0x10000000, PA:0x10001000) mmio (READ | WRITE | DEVICE | RESERVED)
[  0.034322 0 arceboot:19]   [PA:0x10001000, PA:0x10009000) mmio (READ | WRITE | DEVICE | RESERVED)
[  0.035466 0 arceboot:19]   [PA:0x30000000, PA:0x40000000) mmio (READ | WRITE | DEVICE | RESERVED)
[  0.036583 0 arceboot:19]   [PA:0x40000000, PA:0x80000000) mmio (READ | WRITE | DEVICE | RESERVED)
[  0.037733 0 arceboot:67] Initialize global memory allocator...
[  0.038380 0 arceboot:68]   use TLSF allocator.
[  0.039217 0 axhal::mem:130] default free regions
[  0.039872 0 axhal::mem:130] default free regions
[  0.040607 0 axalloc:217] initialize global allocator at: [0xffffffc08025d000, 0xffffffc088000000)
[  0.042658 0 axhal::mem:130] default free regions
[  0.043322 0 axmm:72] Initialize virtual memory management...
[  0.044405 0 axhal::mem:130] default free regions
[  0.045473 0 axmm::backend::linear:21] map_linear: [VA:0xffffffc080200000, VA:0xffffffc080210000) -> [PA:0x80200000, PA:0x80210000) READ | EXECUTE
[  0.047602 0 axmm::backend::linear:21] map_linear: [VA:0xffffffc080210000, VA:0xffffffc080216000) -> [PA:0x80210000, PA:0x80216000) READ
[  0.049360 0 axmm::backend::linear:21] map_linear: [VA:0xffffffc080216000, VA:0xffffffc080219000) -> [PA:0x80216000, PA:0x80219000) READ | WRITE
[  0.051108 0 axmm::backend::linear:21] map_linear: [VA:0xffffffc080219000, VA:0xffffffc080259000) -> [PA:0x80219000, PA:0x80259000) READ | WRITE
[  0.052341 0 axmm::backend::linear:21] map_linear: [VA:0xffffffc080259000, VA:0xffffffc08025d000) -> [PA:0x80259000, PA:0x8025d000) READ | WRITE
[  0.053573 0 axmm::backend::linear:21] map_linear: [VA:0xffffffc08025d000, VA:0xffffffc088000000) -> [PA:0x8025d000, PA:0x88000000) READ | WRITE
[  0.060773 0 axmm::backend::linear:21] map_linear: [VA:0xffffffc000101000, VA:0xffffffc000102000) -> [PA:0x101000, PA:0x102000) READ | WRITE | DEVICE
[  0.062209 0 axmm::backend::linear:21] map_linear: [VA:0xffffffc00c000000, VA:0xffffffc00c210000) -> [PA:0xc000000, PA:0xc210000) READ | WRITE | DEVICE
[  0.064207 0 axmm::backend::linear:21] map_linear: [VA:0xffffffc010000000, VA:0xffffffc010001000) -> [PA:0x10000000, PA:0x10001000) READ | WRITE | DEVICE
[  0.065488 0 axmm::backend::linear:21] map_linear: [VA:0xffffffc010001000, VA:0xffffffc010009000) -> [PA:0x10001000, PA:0x10009000) READ | WRITE | DEVICE
[  0.066841 0 axmm::backend::linear:21] map_linear: [VA:0xffffffc030000000, VA:0xffffffc040000000) -> [PA:0x30000000, PA:0x40000000) READ | WRITE | DEVICE
[  0.079890 0 axmm::backend::linear:21] map_linear: [VA:0xffffffc040000000, VA:0xffffffc080000000) -> [PA:0x40000000, PA:0x80000000) READ | WRITE | DEVICE
[  0.144094 0 axmm:75] kernel address space init OK: AddrSpace {
    va_range: VA:0xffffffc000000000..VA:0xfffffffffffff000,
    page_table_root: PA:0x80265000,
    areas: [
        MemoryArea {
            va_range: VA:0xffffffc000101000..VA:0xffffffc000102000,
            flags: READ | WRITE | DEVICE,
        },
        MemoryArea {
            va_range: VA:0xffffffc00c000000..VA:0xffffffc00c210000,
            flags: READ | WRITE | DEVICE,
        },
        MemoryArea {
            va_range: VA:0xffffffc010000000..VA:0xffffffc010001000,
            flags: READ | WRITE | DEVICE,
        },
        MemoryArea {
            va_range: VA:0xffffffc010001000..VA:0xffffffc010009000,
            flags: READ | WRITE | DEVICE,
        },
        MemoryArea {
            va_range: VA:0xffffffc030000000..VA:0xffffffc040000000,
            flags: READ | WRITE | DEVICE,
        },
        MemoryArea {
            va_range: VA:0xffffffc040000000..VA:0xffffffc080000000,
            flags: READ | WRITE | DEVICE,
        },
        MemoryArea {
            va_range: VA:0xffffffc080200000..VA:0xffffffc080210000,
            flags: READ | EXECUTE,
        },
        MemoryArea {
            va_range: VA:0xffffffc080210000..VA:0xffffffc080216000,
            flags: READ,
        },
        MemoryArea {
            va_range: VA:0xffffffc080216000..VA:0xffffffc080219000,
            flags: READ | WRITE,
        },
        MemoryArea {
            va_range: VA:0xffffffc080219000..VA:0xffffffc080259000,
            flags: READ | WRITE,
        },
        MemoryArea {
            va_range: VA:0xffffffc080259000..VA:0xffffffc08025d000,
            flags: READ | WRITE,
        },
        MemoryArea {
            va_range: VA:0xffffffc08025d000..VA:0xffffffc088000000,
            flags: READ | WRITE,
        },
    ],
}
[  0.158372 0 arceboot:34] Initialize platform devices...
[  0.159050 0 axdriver:153] Initialize device drivers...
[  0.159700 0 axdriver:154]   device model: static
[  0.160347 0 axdriver:157]   probing devices...
[  0.160989 0 axdriver:132]   probing devices... up
[  0.161813 0 axdriver::bus::pci:97] PCI 00:00.0: 1b36:0008 (class 06.00, rev 00) Standard
[  0.187995 0 axdriver:134]   probing devices... up down
[  0.188655 0 axdriver:159]   probing devices... down
[  0.189240 0 axdriver:171] number of block devices: 0
[  0.189905 0 arceboot:55] will test cpio.
[  0.190783 0 arceboot::media::ramdisk_cpio:58] Found file: ., size: 0
[  0.191592 0 arceboot::media::ramdisk_cpio:58] Found file: arceboot.txt, size: 34
[  0.192443 0 arceboot::media::ramdisk_cpio:69] Content of arceboot.txt:
This is a test file for Arceboot.

[  0.193351 0 arceboot::media::ramdisk_cpio:54] End of CPIO archive.
[  0.194011 0 arceboot:59] will shut down.
[  0.194676 0 axhal::platform::riscv64_qemu_virt::misc:3] Shutting down...
```